### PR TITLE
Switch to hamming_weight function for X_t weight

### DIFF
--- a/src/decompressor/pocketplusdecompressor.cpp
+++ b/src/decompressor/pocketplusdecompressor.cpp
@@ -141,7 +141,7 @@ std::deque<bool> PocketPlusDecompressor::decompress(std::deque<bool>& input){
 		//std::cout << "D_t: ";
 		//pocketplus::utils::print_vector(D_t);
 	}
-	auto X_t_weight = std::make_unique<unsigned int>(hamming_weight_in_range(X_t.begin(), X_t.end()));
+	auto X_t_weight = std::make_unique<unsigned int>(hamming_weight(X_t));
 	//std::cout << "X_t_weight: " << *X_t_weight << std::endl;
 	bit_position += 2;
 	pocketplus::utils::pop_n_from_front(input, 2);


### PR DESCRIPTION
The X_t weight calculation was still based on the hamming_weight_in_range function, which leads to false results.